### PR TITLE
waydroid: add waydroid_arm64_only target for 64-bit only arm64 devices

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -16,10 +16,10 @@
 
 LOCAL_PATH := $(call my-dir)
 
-ifneq ($(filter waydroid_arm64 waydroid_arm waydroid_x86 waydroid_x86_64,$(TARGET_DEVICE)),)
+ifneq ($(filter waydroid_arm64 waydroid_arm64_only waydroid_arm waydroid_x86 waydroid_x86_64,$(TARGET_DEVICE)),)
 include $(call all-makefiles-under,$(LOCAL_PATH))
 
-ifneq ($(filter waydroid_arm64 waydroid_arm,$(TARGET_DEVICE)),)
+ifneq ($(filter waydroid_arm64 waydroid_arm64_only waydroid_arm,$(TARGET_DEVICE)),)
 MPVR_SYMLINK += $(TARGET_OUT_VENDOR)/lib/libmpvr.so
 $(MPVR_SYMLINK): $(LOCAL_INSTALLED_MODULE)
 	@mkdir -p $(dir $@)
@@ -41,7 +41,7 @@ $(EGL_MOUNT_POINT): $(LOCAL_INSTALLED_MODULE)
 ALL_DEFAULT_INSTALLED_MODULES += $(EGL_MOUNT_POINT)
 endif
 
-ifneq ($(filter waydroid_arm64,$(TARGET_DEVICE)),)
+ifneq ($(filter waydroid_arm64 waydroid_arm64_only,$(TARGET_DEVICE)),)
 MPVR64_SYMLINK += $(TARGET_OUT_VENDOR)/lib64/libmpvr.so
 $(MPVR64_SYMLINK): $(LOCAL_INSTALLED_MODULE)
 	@mkdir -p $(dir $@)

--- a/AndroidProducts.mk
+++ b/AndroidProducts.mk
@@ -23,6 +23,7 @@ endif
 
 PRODUCT_MAKEFILES := \
     $(VENDOR_NAME)_waydroid_arm64:$(LOCAL_DIR)/waydroid_arm64/$(VENDOR_NAME)_waydroid_arm64.mk \
+    $(VENDOR_NAME)_waydroid_arm64_only:$(LOCAL_DIR)/waydroid_arm64_only/$(VENDOR_NAME)_waydroid_arm64_only.mk \
     $(VENDOR_NAME)_waydroid_arm:$(LOCAL_DIR)/waydroid_arm/$(VENDOR_NAME)_waydroid_arm.mk \
     $(VENDOR_NAME)_waydroid_x86:$(LOCAL_DIR)/waydroid_x86/$(VENDOR_NAME)_waydroid_x86.mk \
     $(VENDOR_NAME)_waydroid_x86_64:$(LOCAL_DIR)/waydroid_x86_64/$(VENDOR_NAME)_waydroid_x86_64.mk
@@ -31,6 +32,9 @@ COMMON_LUNCH_CHOICES := \
     $(VENDOR_NAME)_waydroid_arm64-user \
     $(VENDOR_NAME)_waydroid_arm64-userdebug \
     $(VENDOR_NAME)_waydroid_arm64-eng \
+    $(VENDOR_NAME)_waydroid_arm64_only-user \
+    $(VENDOR_NAME)_waydroid_arm64_only-userdebug \
+    $(VENDOR_NAME)_waydroid_arm64_only-eng \
     $(VENDOR_NAME)_waydroid_arm-user \
     $(VENDOR_NAME)_waydroid_arm-userdebug \
     $(VENDOR_NAME)_waydroid_arm-eng \

--- a/waydroid_arm64_only/BoardConfig.mk
+++ b/waydroid_arm64_only/BoardConfig.mk
@@ -1,0 +1,32 @@
+#
+# Copyright (C) 2021 The Waydroid Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+-include device/waydroid/waydroid/BoardConfig.mk
+
+# Architecture
+TARGET_ARCH := arm64
+TARGET_ARCH_VARIANT := armv8-a
+TARGET_CPU_ABI := arm64-v8a
+TARGET_CPU_ABI2 :=
+TARGET_CPU_VARIANT := generic
+
+TARGET_2ND_ARCH :=
+TARGET_2ND_ARCH_VARIANT :=
+TARGET_2ND_CPU_ABI :=
+TARGET_2ND_CPU_ABI2 :=
+TARGET_2ND_CPU_VARIANT :=
+
+AUDIOSERVER_MULTILIB := first

--- a/waydroid_arm64_only/bliss_waydroid_arm64_only.mk
+++ b/waydroid_arm64_only/bliss_waydroid_arm64_only.mk
@@ -1,0 +1,27 @@
+#
+# Copyright (C) 2021 The Waydroid Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Inherit from those products. Most specific first.
+$(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit_only.mk)
+
+# Inherit from waydroid device
+$(call inherit-product, $(LOCAL_PATH)/../device.mk)
+
+PRODUCT_BRAND := waydroid
+PRODUCT_DEVICE := waydroid_arm64_only
+PRODUCT_MANUFACTURER := Waydroid
+PRODUCT_NAME := bliss_waydroid_arm64_only
+PRODUCT_MODEL := WayDroid arm64 only Device

--- a/waydroid_arm64_only/lineage_waydroid_arm64_only.mk
+++ b/waydroid_arm64_only/lineage_waydroid_arm64_only.mk
@@ -1,0 +1,27 @@
+#
+# Copyright (C) 2021 The Waydroid Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Inherit from those products. Most specific first.
+$(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit_only.mk)
+
+# Inherit from waydroid device
+$(call inherit-product, $(LOCAL_PATH)/../device.mk)
+
+PRODUCT_BRAND := waydroid
+PRODUCT_DEVICE := waydroid_arm64_only
+PRODUCT_MANUFACTURER := Waydroid
+PRODUCT_NAME := lineage_waydroid_arm64_only
+PRODUCT_MODEL := WayDroid arm64 only Device


### PR DESCRIPTION
Some arm64 devices, such as Apple Silicon Macs, do not support 32-bit arm code. The regular arm64 images do not run on them as still contain arm32 services, such as the media server and audio server.

Add an extra build target that builds a 64-bit only arm64 image for these devices.

Note that this also requires copying frameworks/av/services/mediacodec/seccomp_policy/mediacodec-arm64.policy from Android 11. I can add a patch for that as well if you want.

Tested in waydroid 1.2.1 running in Fedora 36 in a virtual machine in UTM (QEMU frontend) on macOS 12.3.1