### PR TITLE
Delete -Dintel-xe-kmd=enabled from BoardConfig.mk

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -40,7 +40,7 @@ TARGET_NO_BOOTLOADER := true
 TARGET_USES_HWC2 := true
 ifneq ($(TARGET_USE_MESA),false)
 BOARD_MESA3D_USES_MESON_BUILD := true
-BOARD_MESA3D_MESON_ARGS := -Dallow-kcmp=enabled -Dintel-xe-kmd=enabled
+BOARD_MESA3D_MESON_ARGS := -Dallow-kcmp=enabled
 BOARD_MESA3D_BUILD_LIBGBM := true
 BOARD_MESA3D_GALLIUM_DRIVERS := kmsro r300 r600 nouveau freedreno swrast v3d vc4 etnaviv tegra svga virgl panfrost lima radeonsi
 BOARD_MESA3D_VULKAN_DRIVERS := broadcom freedreno panfrost swrast virtio amd


### PR DESCRIPTION
The option is no longer in use due to a commit https://github.com/waydroid/android_external_mesa3d/commit/066c61c7485e24394fe76d17d201bc479f7cbd16

Because of this option we get an error when building vendorimage

```bash
meson.build:21:0: ERROR: Unknown options: "intel-xe-kmd"
```