### PR TITLE
Add Android TV config for x86-64

### DIFF
--- a/AndroidProducts.mk
+++ b/AndroidProducts.mk
@@ -47,4 +47,4 @@ COMMON_LUNCH_CHOICES := \
     $(VENDOR_NAME)_waydroid_x86_64-eng \
     $(VENDOR_NAME)_waydroid_atv_x86_64-user \
     $(VENDOR_NAME)_waydroid_atv_x86_64-userdebug \
-    $(VENDOR_NAME)_waydroid_atv_x86_64-usereng
+    $(VENDOR_NAME)_waydroid_atv_x86_64-eng

--- a/AndroidProducts.mk
+++ b/AndroidProducts.mk
@@ -26,7 +26,8 @@ PRODUCT_MAKEFILES := \
     $(VENDOR_NAME)_waydroid_arm64_only:$(LOCAL_DIR)/waydroid_arm64_only/$(VENDOR_NAME)_waydroid_arm64_only.mk \
     $(VENDOR_NAME)_waydroid_arm:$(LOCAL_DIR)/waydroid_arm/$(VENDOR_NAME)_waydroid_arm.mk \
     $(VENDOR_NAME)_waydroid_x86:$(LOCAL_DIR)/waydroid_x86/$(VENDOR_NAME)_waydroid_x86.mk \
-    $(VENDOR_NAME)_waydroid_x86_64:$(LOCAL_DIR)/waydroid_x86_64/$(VENDOR_NAME)_waydroid_x86_64.mk
+    $(VENDOR_NAME)_waydroid_x86_64:$(LOCAL_DIR)/waydroid_x86_64/$(VENDOR_NAME)_waydroid_x86_64.mk \
+    $(VENDOR_NAME)_waydroid_atv_x86_64:$(LOCAL_DIR)/waydroid_x86_64/$(VENDOR_NAME)_waydroid_atv_x86_64.mk
 
 COMMON_LUNCH_CHOICES := \
     $(VENDOR_NAME)_waydroid_arm64-user \
@@ -43,4 +44,7 @@ COMMON_LUNCH_CHOICES := \
     $(VENDOR_NAME)_waydroid_x86-eng \
     $(VENDOR_NAME)_waydroid_x86_64-user \
     $(VENDOR_NAME)_waydroid_x86_64-userdebug \
-    $(VENDOR_NAME)_waydroid_x86_64-eng
+    $(VENDOR_NAME)_waydroid_x86_64-eng \
+    $(VENDOR_NAME)_waydroid_atv_x86_64-user \
+    $(VENDOR_NAME)_waydroid_atv_x86_64-userdebug \
+    $(VENDOR_NAME)_waydroid_atv_x86_64-usereng

--- a/device.mk
+++ b/device.mk
@@ -14,13 +14,22 @@
 # limitations under the License.
 #
 
+$(call inherit-product, $(SRC_TARGET_DIR)/product/product_launched_with_p.mk)
+
+ifeq ($(PRODUCT_IS_ATV),true)
+# Inherit from atv products.
+$(call inherit-product, device/google/atv/products/atv_base.mk)
+
+# Inherit some common ROM stuff
+$(call inherit-product-if-exists, vendor/lineage/config/common_full_tv.mk)
+else
 # Inherit from aosp products.
 $(call inherit-product, $(SRC_TARGET_DIR)/product/full_base.mk)
-$(call inherit-product, $(SRC_TARGET_DIR)/product/product_launched_with_p.mk)
 
 # Inherit some common ROM stuff
 $(call inherit-product-if-exists, vendor/lineage/config/common_full_tablet_wifionly.mk)
 $(call inherit-product-if-exists, vendor/bliss/config/common_full_tablet_wifionly.mk)
+endif
 
 # Audio HAL
 PRODUCT_PACKAGES += \
@@ -86,7 +95,7 @@ PRODUCT_PACKAGES += \
     vulkan.virtio \
     vulkan.lvp
 
-ifneq ($(filter %_waydroid_x86 %_waydroid_x86_64,$(TARGET_PRODUCT)),)
+ifneq ($(filter %_waydroid_x86 %_waydroid_x86_64 %_waydroid_atv_x86_64,$(TARGET_PRODUCT)),)
 PRODUCT_PACKAGES += \
     vulkan.intel \
     vulkan.intel_hasvk
@@ -130,7 +139,7 @@ PRODUCT_COPY_FILES += \
     frameworks/av/media/libstagefright/data/media_codecs_google_video.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs_google_video.xml
 
 # Media - Stagefright FFMPEG plugin
-ifneq ($(filter %_waydroid_x86 %_waydroid_x86_64,$(TARGET_PRODUCT)),)
+ifneq ($(filter %_waydroid_x86 %_waydroid_x86_64 %_waydroid_atv_x86_64,$(TARGET_PRODUCT)),)
 PRODUCT_PACKAGES += \
     libffmpeg_omx \
     media_codecs_ffmpeg.xml

--- a/waydroid_x86_64/lineage_waydroid_atv_x86_64.mk
+++ b/waydroid_x86_64/lineage_waydroid_atv_x86_64.mk
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2021 The Waydroid Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Inherit from those products. Most specific first.
+$(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
+
+PRODUCT_IS_ATV := true
+
+# Inherit from waydroid device
+$(call inherit-product, $(LOCAL_PATH)/../device.mk)
+
+PRODUCT_BRAND := waydroid
+PRODUCT_DEVICE := waydroid_atv_x86_64
+PRODUCT_MANUFACTURER := Waydroid
+PRODUCT_NAME := lineage_waydroid_atv_x86_64
+PRODUCT_MODEL := WayDroid x86_64 Android TV Device


### PR DESCRIPTION
Fixes https://github.com/waydroid/waydroid/issues/1189
Fixes https://github.com/waydroid/waydroid/discussions/554

This PR adds a new configuration for x86-64 devices, which is based on the TV form-factor and uses ATV version of system apps (launcher, settings, etc).

Not sure if this is the right way 😅 (this is my first time dealing with AOSP things)

I have managed to build a fully functional (except the onscreen keyboard) Android TV image for Waydroid using the `common_full_tv.mk` config, see [here](https://github.com/supechicken/waydroid-androidtv-build) for more infomation