### PR TITLE
Add foss build-type inherit

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -215,3 +215,8 @@ endif
 # Updater
 PRODUCT_PACKAGES += \
     WaydroidUpdater
+
+# FOSS Apps
+ifeq ($(LINEAGE_BUILDTYPE), foss)
+$(call inherit-product, vendor/foss/foss.mk)
+endif


### PR DESCRIPTION
Used with build env flag:
export LINEAGE_BUILDTYPE=FOSS
