### PR TITLE
Add ATV target for all architectures

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -16,10 +16,10 @@
 
 LOCAL_PATH := $(call my-dir)
 
-ifneq ($(filter waydroid_arm64 waydroid_arm64_only waydroid_arm waydroid_x86 waydroid_x86_64,$(TARGET_DEVICE)),)
+ifneq ($(filter waydroid_%,$(TARGET_DEVICE)),)
 include $(call all-makefiles-under,$(LOCAL_PATH))
 
-ifneq ($(filter waydroid_arm64 waydroid_arm64_only waydroid_arm,$(TARGET_DEVICE)),)
+ifneq ($(filter waydroid_arm64 waydroid_arm64_only waydroid_arm waydroid_tv_arm64 waydroid_tv_arm64_only waydroid_tv_arm,$(TARGET_DEVICE)),)
 MPVR_SYMLINK += $(TARGET_OUT_VENDOR)/lib/libmpvr.so
 $(MPVR_SYMLINK): $(LOCAL_INSTALLED_MODULE)
 	@mkdir -p $(dir $@)
@@ -41,7 +41,7 @@ $(EGL_MOUNT_POINT): $(LOCAL_INSTALLED_MODULE)
 ALL_DEFAULT_INSTALLED_MODULES += $(EGL_MOUNT_POINT)
 endif
 
-ifneq ($(filter waydroid_arm64 waydroid_arm64_only,$(TARGET_DEVICE)),)
+ifneq ($(filter waydroid_arm64 waydroid_arm64_only waydroid_tv_arm64 waydroid_tv_arm64_only,$(TARGET_DEVICE)),)
 MPVR64_SYMLINK += $(TARGET_OUT_VENDOR)/lib64/libmpvr.so
 $(MPVR64_SYMLINK): $(LOCAL_INSTALLED_MODULE)
 	@mkdir -p $(dir $@)

--- a/Android.mk
+++ b/Android.mk
@@ -19,7 +19,7 @@ LOCAL_PATH := $(call my-dir)
 ifneq ($(filter waydroid_%,$(TARGET_DEVICE)),)
 include $(call all-makefiles-under,$(LOCAL_PATH))
 
-ifneq ($(filter waydroid_arm64 waydroid_arm64_only waydroid_arm waydroid_tv_arm64 waydroid_tv_arm64_only waydroid_tv_arm,$(TARGET_DEVICE)),)
+ifneq ($(filter waydroid_arm64 waydroid_arm64_only waydroid_arm,$(TARGET_DEVICE)),)
 MPVR_SYMLINK += $(TARGET_OUT_VENDOR)/lib/libmpvr.so
 $(MPVR_SYMLINK): $(LOCAL_INSTALLED_MODULE)
 	@mkdir -p $(dir $@)
@@ -41,7 +41,7 @@ $(EGL_MOUNT_POINT): $(LOCAL_INSTALLED_MODULE)
 ALL_DEFAULT_INSTALLED_MODULES += $(EGL_MOUNT_POINT)
 endif
 
-ifneq ($(filter waydroid_arm64 waydroid_arm64_only waydroid_tv_arm64 waydroid_tv_arm64_only,$(TARGET_DEVICE)),)
+ifneq ($(filter waydroid_arm64 waydroid_arm64_only,$(TARGET_DEVICE)),)
 MPVR64_SYMLINK += $(TARGET_OUT_VENDOR)/lib64/libmpvr.so
 $(MPVR64_SYMLINK): $(LOCAL_INSTALLED_MODULE)
 	@mkdir -p $(dir $@)

--- a/AndroidProducts.mk
+++ b/AndroidProducts.mk
@@ -26,7 +26,12 @@ PRODUCT_MAKEFILES := \
     $(VENDOR_NAME)_waydroid_arm64_only:$(LOCAL_DIR)/waydroid_arm64_only/$(VENDOR_NAME)_waydroid_arm64_only.mk \
     $(VENDOR_NAME)_waydroid_arm:$(LOCAL_DIR)/waydroid_arm/$(VENDOR_NAME)_waydroid_arm.mk \
     $(VENDOR_NAME)_waydroid_x86:$(LOCAL_DIR)/waydroid_x86/$(VENDOR_NAME)_waydroid_x86.mk \
-    $(VENDOR_NAME)_waydroid_x86_64:$(LOCAL_DIR)/waydroid_x86_64/$(VENDOR_NAME)_waydroid_x86_64.mk
+    $(VENDOR_NAME)_waydroid_x86_64:$(LOCAL_DIR)/waydroid_x86_64/$(VENDOR_NAME)_waydroid_x86_64.mk \
+    $(VENDOR_NAME)_waydroid_tv_arm64:$(LOCAL_DIR)/waydroid_tv_arm64/$(VENDOR_NAME)_waydroid_tv_arm64.mk \
+    $(VENDOR_NAME)_waydroid_tv_arm64_only:$(LOCAL_DIR)/waydroid_tv_arm64_only/$(VENDOR_NAME)_waydroid_tv_arm64_only.mk \
+    $(VENDOR_NAME)_waydroid_tv_arm:$(LOCAL_DIR)/waydroid_tv_arm/$(VENDOR_NAME)_waydroid_tv_arm.mk \
+    $(VENDOR_NAME)_waydroid_tv_x86:$(LOCAL_DIR)/waydroid_tv_x86/$(VENDOR_NAME)_waydroid_tv_x86.mk \
+    $(VENDOR_NAME)_waydroid_tv_x86_64:$(LOCAL_DIR)/waydroid_tv_x86_64/$(VENDOR_NAME)_waydroid_tv_x86_64.mk
 
 COMMON_LUNCH_CHOICES := \
     $(VENDOR_NAME)_waydroid_arm64-user \
@@ -43,4 +48,19 @@ COMMON_LUNCH_CHOICES := \
     $(VENDOR_NAME)_waydroid_x86-eng \
     $(VENDOR_NAME)_waydroid_x86_64-user \
     $(VENDOR_NAME)_waydroid_x86_64-userdebug \
-    $(VENDOR_NAME)_waydroid_x86_64-eng
+    $(VENDOR_NAME)_waydroid_x86_64-eng \
+    $(VENDOR_NAME)_waydroid_tv_arm64-user \
+    $(VENDOR_NAME)_waydroid_tv_arm64-userdebug \
+    $(VENDOR_NAME)_waydroid_tv_arm64-eng \
+    $(VENDOR_NAME)_waydroid_tv_arm64_only-user \
+    $(VENDOR_NAME)_waydroid_tv_arm64_only-userdebug \
+    $(VENDOR_NAME)_waydroid_tv_arm64_only-eng \
+    $(VENDOR_NAME)_waydroid_tv_arm-user \
+    $(VENDOR_NAME)_waydroid_tv_arm-userdebug \
+    $(VENDOR_NAME)_waydroid_tv_arm-eng \
+    $(VENDOR_NAME)_waydroid_tv_x86-user \
+    $(VENDOR_NAME)_waydroid_tv_x86-userdebug \
+    $(VENDOR_NAME)_waydroid_tv_x86-eng \
+    $(VENDOR_NAME)_waydroid_tv_x86_64-user \
+    $(VENDOR_NAME)_waydroid_tv_x86_64-userdebug \
+    $(VENDOR_NAME)_waydroid_tv_x86_64-eng

--- a/device.mk
+++ b/device.mk
@@ -239,7 +239,7 @@ PRODUCT_SOONG_NAMESPACES += \
 PRODUCT_PACKAGES += \
     vndservicemanager
 
-ifeq ($(filter %_waydroid_x86 %_waydroid_x86_64 %_waydroid_tv_x86 %_waydroid_tv_x86_64,$(TARGET_PRODUCT)),)
+ifeq ($(filter %_waydroid_x86 %_waydroid_x86_64 %_waydroid_tv%,$(TARGET_PRODUCT)),)
 PRODUCT_EXTRA_VNDK_VERSIONS := 28 29 30
 endif
 

--- a/device.mk
+++ b/device.mk
@@ -14,13 +14,22 @@
 # limitations under the License.
 #
 
+ifeq ($(PRODUCT_IS_ATV),true)
+# Inherit from atv products.
+$(call inherit-product, device/google/atv/products/atv_base.mk)
+
+# Inherit some common ROM stuff
+$(call inherit-product-if-exists, vendor/lineage/config/common_full_tv.mk)
+else
 # Inherit from aosp products.
 $(call inherit-product, $(SRC_TARGET_DIR)/product/full_base.mk)
-$(call inherit-product, $(SRC_TARGET_DIR)/product/product_launched_with_p.mk)
 
 # Inherit some common ROM stuff
 $(call inherit-product-if-exists, vendor/lineage/config/common_full_tablet_wifionly.mk)
 $(call inherit-product-if-exists, vendor/bliss/config/common_full_tablet_wifionly.mk)
+endif
+
+$(call inherit-product, $(SRC_TARGET_DIR)/product/product_launched_with_p.mk)
 
 # Enable automatic partition size
 PRODUCT_USE_DYNAMIC_PARTITION_SIZE := true
@@ -154,7 +163,7 @@ PRODUCT_COPY_FILES += \
 endif
 
 # Media - Stagefright FFMPEG plugin
-ifneq ($(filter %_waydroid_x86 %_waydroid_x86_64,$(TARGET_PRODUCT)),)
+ifneq ($(filter %_waydroid_x86 %_waydroid_x86_64 %_waydroid_tv_x86 %_waydroid_tv_x86_64,$(TARGET_PRODUCT)),)
 PRODUCT_PACKAGES += \
     libffmpeg_omx \
     media_codecs_ffmpeg.xml
@@ -230,7 +239,7 @@ PRODUCT_SOONG_NAMESPACES += \
 PRODUCT_PACKAGES += \
     vndservicemanager
 
-ifeq ($(filter %_waydroid_x86 %_waydroid_x86_64,$(TARGET_PRODUCT)),)
+ifeq ($(filter %_waydroid_x86 %_waydroid_x86_64 %_waydroid_tv_x86 %_waydroid_tv_x86_64,$(TARGET_PRODUCT)),)
 PRODUCT_EXTRA_VNDK_VERSIONS := 28 29 30
 endif
 

--- a/waydroid_tv_arm/BoardConfig.mk
+++ b/waydroid_tv_arm/BoardConfig.mk
@@ -1,0 +1,32 @@
+#
+# Copyright (C) 2021 The Waydroid Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+-include device/waydroid/waydroid/BoardConfig.mk
+
+# Architecture
+TARGET_ARCH := arm
+TARGET_ARCH_VARIANT := armv7-a-neon
+TARGET_CPU_ABI := armeabi-v7a
+TARGET_CPU_ABI2 := armeabi
+TARGET_CPU_VARIANT := generic
+
+# Disable scudo
+MALLOC_SVELTE := true
+
+ifneq ($(TARGET_USE_MESA),false)
+BOARD_MESA3D_GALLIUM_DRIVERS += freedreno v3d vc4 etnaviv tegra panfrost lima
+BOARD_MESA3D_VULKAN_DRIVERS += broadcom freedreno panfrost
+endif

--- a/waydroid_tv_arm/lineage_waydroid_tv_arm.mk
+++ b/waydroid_tv_arm/lineage_waydroid_tv_arm.mk
@@ -1,0 +1,26 @@
+#
+# Copyright (C) 2021 The Waydroid Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+PRODUCT_IS_ATV := true
+
+# Inherit from waydroid device
+$(call inherit-product, $(LOCAL_PATH)/../device.mk)
+
+PRODUCT_BRAND := waydroid
+PRODUCT_DEVICE := waydroid_arm
+PRODUCT_MANUFACTURER := Waydroid
+PRODUCT_NAME := lineage_waydroid_tv_arm
+PRODUCT_MODEL := WayDroid arm Device (32-bit only) (TV form factor)

--- a/waydroid_tv_arm64/BoardConfig.mk
+++ b/waydroid_tv_arm64/BoardConfig.mk
@@ -1,0 +1,38 @@
+#
+# Copyright (C) 2021 The Waydroid Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+-include device/waydroid/waydroid/BoardConfig.mk
+
+# Architecture
+TARGET_ARCH := arm64
+TARGET_ARCH_VARIANT := armv8-a
+TARGET_CPU_ABI := arm64-v8a
+TARGET_CPU_ABI2 :=
+TARGET_CPU_VARIANT := generic
+
+TARGET_2ND_ARCH := arm
+TARGET_2ND_ARCH_VARIANT := armv8-a
+TARGET_2ND_CPU_ABI := armeabi-v7a
+TARGET_2ND_CPU_ABI2 := armeabi
+TARGET_2ND_CPU_VARIANT := generic
+
+# Disable scudo
+MALLOC_SVELTE := true
+
+ifneq ($(TARGET_USE_MESA),false)
+BOARD_MESA3D_GALLIUM_DRIVERS += freedreno v3d vc4 etnaviv tegra panfrost lima
+BOARD_MESA3D_VULKAN_DRIVERS += broadcom freedreno panfrost
+endif

--- a/waydroid_tv_arm64/lineage_waydroid_tv_arm64.mk
+++ b/waydroid_tv_arm64/lineage_waydroid_tv_arm64.mk
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2021 The Waydroid Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+PRODUCT_IS_ATV := true
+
+# Inherit from those products. Most specific first.
+$(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
+
+# Inherit from waydroid device
+$(call inherit-product, $(LOCAL_PATH)/../device.mk)
+
+PRODUCT_BRAND := waydroid
+PRODUCT_DEVICE := waydroid_tv_arm64
+PRODUCT_MANUFACTURER := Waydroid
+PRODUCT_NAME := lineage_waydroid_tv_arm64
+PRODUCT_MODEL := WayDroid arm64 Device (TV form factor)

--- a/waydroid_tv_arm64_only/BoardConfig.mk
+++ b/waydroid_tv_arm64_only/BoardConfig.mk
@@ -1,0 +1,40 @@
+#
+# Copyright (C) 2021 The Waydroid Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+-include device/waydroid/waydroid/BoardConfig.mk
+
+# Architecture
+TARGET_ARCH := arm64
+TARGET_ARCH_VARIANT := armv8-a
+TARGET_CPU_ABI := arm64-v8a
+TARGET_CPU_ABI2 :=
+TARGET_CPU_VARIANT := generic
+
+TARGET_2ND_ARCH :=
+TARGET_2ND_ARCH_VARIANT :=
+TARGET_2ND_CPU_ABI :=
+TARGET_2ND_CPU_ABI2 :=
+TARGET_2ND_CPU_VARIANT :=
+
+# Disable scudo
+MALLOC_SVELTE := true
+
+AUDIOSERVER_MULTILIB := first
+
+ifneq ($(TARGET_USE_MESA),false)
+BOARD_MESA3D_GALLIUM_DRIVERS += freedreno v3d vc4 etnaviv tegra panfrost lima
+BOARD_MESA3D_VULKAN_DRIVERS += broadcom freedreno panfrost
+endif

--- a/waydroid_tv_arm64_only/lineage_waydroid_tv_arm64_only.mk
+++ b/waydroid_tv_arm64_only/lineage_waydroid_tv_arm64_only.mk
@@ -1,0 +1,30 @@
+#
+# Copyright (C) 2021 The Waydroid Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+PRODUCT_IS_ATV := true
+TARGET_SUPPORTS_OMX_SERVICE := true
+
+# Inherit from those products. Most specific first.
+$(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit_only.mk)
+
+# Inherit from waydroid device
+$(call inherit-product, $(LOCAL_PATH)/../device.mk)
+
+PRODUCT_BRAND := waydroid
+PRODUCT_DEVICE := waydroid_tv_arm64_only
+PRODUCT_MANUFACTURER := Waydroid
+PRODUCT_NAME := lineage_waydroid_tv_arm64_only
+PRODUCT_MODEL := WayDroid arm64 only Device (TV form factor)

--- a/waydroid_tv_x86/BoardConfig.mk
+++ b/waydroid_tv_x86/BoardConfig.mk
@@ -1,0 +1,30 @@
+#
+# Copyright (C) 2021 The Waydroid Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+-include device/waydroid/waydroid/BoardConfig.mk
+
+# Architecture
+TARGET_CPU_ABI := x86
+TARGET_ARCH := x86
+TARGET_ARCH_VARIANT := x86
+
+ifneq ($(TARGET_USE_MESA),false)
+BOARD_MESA3D_GALLIUM_DRIVERS += i915 iris crocus
+BOARD_MESA3D_VULKAN_DRIVERS += intel intel_hasvk
+endif
+
+# Disable scudo
+MALLOC_SVELTE := true

--- a/waydroid_tv_x86/lineage_waydroid_tv_x86.mk
+++ b/waydroid_tv_x86/lineage_waydroid_tv_x86.mk
@@ -1,0 +1,26 @@
+#
+# Copyright (C) 2021 The Waydroid Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+PRODUCT_IS_ATV := true
+
+# Inherit from waydroid device
+$(call inherit-product, $(LOCAL_PATH)/../device.mk)
+
+PRODUCT_BRAND := waydroid
+PRODUCT_DEVICE := waydroid_tv_x86
+PRODUCT_MANUFACTURER := Waydroid
+PRODUCT_NAME := lineage_waydroid_tv_x86
+PRODUCT_MODEL := WayDroid x86 Device (TV form factor)

--- a/waydroid_tv_x86_64/BoardConfig.mk
+++ b/waydroid_tv_x86_64/BoardConfig.mk
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2021 The Waydroid Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+-include device/waydroid/waydroid/BoardConfig.mk
+
+# Architecture
+TARGET_CPU_ABI := x86_64
+TARGET_ARCH := x86_64
+TARGET_ARCH_VARIANT := x86_64
+
+TARGET_2ND_CPU_ABI := x86
+TARGET_2ND_ARCH := x86
+TARGET_2ND_ARCH_VARIANT := x86_64
+
+ifneq ($(TARGET_USE_MESA),false)
+BOARD_MESA3D_GALLIUM_DRIVERS += i915 iris crocus
+BOARD_MESA3D_VULKAN_DRIVERS += intel intel_hasvk
+endif

--- a/waydroid_tv_x86_64/lineage_waydroid_tv_x86_64.mk
+++ b/waydroid_tv_x86_64/lineage_waydroid_tv_x86_64.mk
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2021 The Waydroid Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+PRODUCT_IS_ATV := true
+
+# Inherit from those products. Most specific first.
+$(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
+
+# Inherit from waydroid device
+$(call inherit-product, $(LOCAL_PATH)/../device.mk)
+
+PRODUCT_BRAND := waydroid
+PRODUCT_DEVICE := waydroid_tv_x86_64
+PRODUCT_MANUFACTURER := Waydroid
+PRODUCT_NAME := lineage_waydroid_tv_x86_64
+PRODUCT_MODEL := WayDroid x86_64 Device (TV form factor)


### PR DESCRIPTION
Revisit of #7 which works 😅
Closes https://github.com/waydroid/waydroid/issues/1189
Closes https://github.com/waydroid/waydroid/discussions/554

This PR adds a TV target for all architectures, which uses ATV configs from LineageOS and has a TV version of system apps (launcher, settings, etc).

The new target is named `lineage_waydroid_tv_<arch>-<variant>`

---

Some minor things are broken and require a patch to fix them (will open another PR in `android_vendor_waydroid` once this is merged):

- The built-in keyboard doesn't work by default [(although re-mapping the enter key to `DPAD_CENTER` fixed it, patching `LeanbackKeyboardController.java` directly will be a better option)](https://github.com/Waydroid-ATV/android_vendor_waydroid/commit/5e2da6a859075ec376dbcc309e8715859790cf2f)
- Developer options tab crashing [(fixed by patching the `updateUsbConfigurationValues()` function)](https://github.com/Waydroid-ATV/android_vendor_waydroid/commit/09b6e4c6314ced83a2f7d1a58e67b6b15dd73b32)